### PR TITLE
Removing everything related to the use of a default url option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,6 @@ export default function graphqlHTTP(options) {
         let operationName;
         let validationRules;
 
-        let urlRoot;
         let optionsData;
         let result; //the content of response.body
         try {
@@ -70,11 +69,6 @@ export default function graphqlHTTP(options) {
                 validationRules = validationRules.concat(optionsData.validationRules);
             }
 
-
-            optionsData.url = optionsData.url || '/graphql';
-            urlRoot = optionsData.url;
-            //add url
-            if (!ctx.url.startsWith(urlRoot)) return next();
 
             // GraphQL HTTP only supports GET and POST methods.
             if (ctx.request.method !== 'GET' && ctx.request.method !== 'POST') {


### PR DESCRIPTION
Hello. This, at first, might appear to be a good idea but is actually not since a `graphql` server is often wrapped into a custom middleware and mounted to a custom path. From my perspective (and because I admit I've spent 2 hours finding the issue, nah OK I haven't read the docs, my bad right) this creates more code friction than necessary. Anyway, this is widely arguable though...